### PR TITLE
rename all models to model or modelPrimitiveName

### DIFF
--- a/tests/floor.apln
+++ b/tests/floor.apln
@@ -12,22 +12,22 @@
     ⍝ 0     0       1           123→123
     ⍝ 1     1       0           ¯123.32→¯124
     ⍝ 1     0       1           ¯123→¯123
-    genFloor←{
+    modelFloor←{
         ⎕pp←34                  ⍝ set to max as we are using strings, the execute and format primitives round the number to the ⎕pp value
         dotPos←⍸,'.'⍷⍕⍵         ⍝ convert num to string and get position of the decimal point
         int←⍎(⍕⍵)↑⍨¯1+dotPos    ⍝ strip integer based on the decimal point
         int-(⍵<0)∧(~0∊⍴dotPos)  ⍝ Subtract 1 only when negative+non int component exists. eg: ¯123.32→¯124
     }
-    ⍝ genFloor←{(⍎(⍕⍵)↑⍨¯1+⍸,'.'⍷(⍕⍵))-(⍵<0)∧(~0∊⍴(⍸,'.'⍷(⍕⍵)))}
+    ⍝ modelFloor←{(⍎(⍕⍵)↑⍨¯1+⍸,'.'⍷(⍕⍵))-(⍵<0)∧(~0∊⍴(⍸,'.'⍷(⍕⍵)))}
 
     ⍝ Generator function for complex floor
     ⍝ interpreted from: https://aplwiki.com/wiki/Complex_floor
-    genCmplxFloor←{
+    modelCmpxFloor←{
         r←9○⍵
         i←11○⍵
-        b←(genFloor r)+0j1×genFloor i
-        x←r-genFloor r
-        y←i-genFloor i
+        b←(modelFloor r)+0j1×modelFloor i
+        x←r-modelFloor r
+        y←i-modelFloor i
         1>x+y: b
         x≥y: b+1
         b+0j1
@@ -104,17 +104,17 @@
                     :For case2 :In 'bool' 'i1' 'i2' 'i3' 'dbl' 'fl' 'Hdbl' 'Hfl'
                         data2←⍎case2
                         desc←testDesc⍬
-                        r,← 'TCross1' desc RunVariations (genFloor¨ data,data2) (data,data2) ⍝ concat data and data2
-                        r,← 'TCross2' desc RunVariations (genFloor¨ data2,data) (data2,data) ⍝ concat data and data2 reversed
+                        r,← 'TCross1' desc RunVariations (modelFloor¨ data,data2) (data,data2) ⍝ concat data and data2
+                        r,← 'TCross2' desc RunVariations (modelFloor¨ data2,data) (data2,data) ⍝ concat data and data2 reversed
                     :EndFor
 
                     case2←⍬ ⍝ disposing case2 for testDesc
                     desc←testDesc⍬
 
-                    r,← 'T1' desc RunVariations (genFloor¨data) data                            ⍝ generator func finds results on array
+                    r,← 'T1' desc RunVariations (modelFloor¨data) data                            ⍝ generator func finds results on array
 
                     dataplus←data+?0⍨¨data                                                      ⍝ data plus a number between (0,1) to data
-                    r,← 'T2' desc Assert ((genFloor¨dataplus)≡⌊dataplus) ∨ ((fr=1) ∧ case≡'Hfl')  ⍝ ⎕fr=645 and Hfl is skipped because of rounding off 
+                    r,← 'T2' desc Assert ((modelFloor¨dataplus)≡⌊dataplus) ∨ ((fr=1) ∧ case≡'Hfl')  ⍝ ⎕fr=645 and Hfl is skipped because of rounding off 
 
                     :If (⊂data)∊i1 i2 i3
                         r,← 'TInt1' desc RunVariations data data                                ⍝ floor of integers will always be floor
@@ -184,7 +184,7 @@
 
                     ⍝ adding a number between (0,1) to data making it a array of cmplx numbers of type xJy ¯xJy xJ¯y ¯xJ¯y
                     dataplus←(data,(data+2⊃⊣),(data+2⊃⊣),(data+(1⊃⊣)+2⊃⊣)) (?0⍨¨data) (¯11○(?0⍨¨data))
-                    r,←'T2' desc Assert ((genCmplxFloor¨dataplus)≡⌊dataplus) ∨ ((fr=2) ∧ case≡'Hcmplx') ⍝ DECF Hcmplx is skipped because of rounding off
+                    r,←'T2' desc Assert ((modelCmpxFloor¨dataplus)≡⌊dataplus) ∨ ((fr=2) ∧ case≡'Hcmplx') ⍝ DECF Hcmplx is skipped because of rounding off
 
                     d1←data[?≢data]
                     almostd1←d1×1-fr⊃1E¯2× ct_default dct_default ⍝ infinitesimally close to d1 but smaller

--- a/tests/indexof.apln
+++ b/tests/indexof.apln
@@ -5,7 +5,7 @@
 :Namespace indexof
     Assert←#.unittest.Assert
 
-    Model←{(⎕IO+1+≢⍺)-+/∨\1,⍨⍵∘.≡⍺}
+    model←{(⎕IO+1+≢⍺)-+/∨\1,⍨⍵∘.≡⍺}
 
     ⍝ Run Variations of each test with normal, empty and multiple shaped data
     ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;left;right;res;tID;tCmt;lshape;larg;rarg;rindex;r;x;n;expectedRM;actualRM
@@ -30,7 +30,7 @@
         :If left≡⍬ ⍝ All cells will be identical
             expectedRM←(≢⊃rindex)⍴⎕IO
         :ElseIf 11≡⎕DR left
-            expectedRM←((⊂⍤¯1) larg) Model ((⊂⍤¯1) rarg) ⍝ use (slow, hungry) model
+            expectedRM←((⊂⍤¯1) larg) model ((⊂⍤¯1) rarg) ⍝ use (slow, hungry) model
         :Else
             expectedRM←⊃rindex
         :EndIf

--- a/tests/magnitude.apln
+++ b/tests/magnitude.apln
@@ -5,6 +5,8 @@
 ⍝ Note that the magnitude of a complex number a+⍳b is defined to be √(a^2+b^2).
 :Namespace magnitude
     Assert←#.unittest.Assert
+
+    model←{⍵×(¯1@(∊∘0)(⍵>0))}
     
     ⍝ Run Variations of each test with normal, empty and multiple shaped data
     ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;left;right;res;tID;tCmt;p;shape;shapeW0;actualRS
@@ -31,7 +33,7 @@
         tRes,←('ShapeW0',tID) tCmt Assert (shapeW0⍴0) ≡ actualRS
     ∇
 
-    ∇ r←test_magnitude_general ;bool;i1;i2;i3;dbl;fl;Hdbl;Hfl;fr_dbl;fr_decf;magGen;case;data;d;testDesc;desc;fr;⎕FR;Sdbl;Sfl
+    ∇ r←test_magnitude_general ;bool;i1;i2;i3;dbl;fl;Hdbl;Hfl;fr_dbl;fr_decf;case;data;d;testDesc;desc;fr;⎕FR;Sdbl;Sfl
         fr_dbl←645
         fr_decf←1287
 
@@ -51,7 +53,6 @@
         ⎕FR←fr_dbl                                    ⍝ revert ⎕FR=645
 
         r←⍬
-        magGen←{⍵×(¯1@(∊∘0)(⍵>0))}
         testDesc←{'for ',case, '& ⎕FR:', ⎕FR}
 
         :For fr :In 1 2
@@ -62,9 +63,9 @@
                 desc←testDesc⍬
                 :If case≢'bool'
                     r,←'T1' desc RunVariations ({(⊣,⊣)((≢⍵)÷2)↑⍵}data) data ⍝ all positive values are chosen
-                    r,←'T2' desc RunVariations (magGen data) data ⍝ custom func finds results on array
+                    r,←'T2' desc RunVariations (model data) data ⍝ custom func finds results on array
                     d←data[?≢data]
-                    r,←'T3' desc RunVariations (magGen d) d ⍝ custom func finds results on single element
+                    r,←'T3' desc RunVariations (model d) d ⍝ custom func finds results on single element
                 :Else
                     r,←'Tb1' desc RunVariations (0 1) bool
                     r,← 'Tb2' desc RunVariations 0 (⊃bool)
@@ -74,7 +75,7 @@
             case←'for limits of i4' ⍝ 32-bit int range [¯2147483648, 2147483647]. Therefore, |¯2147483648 is stored as float.
             desc←testDesc⍬
             r,←'tLim1' desc RunVariations (,2147483648) (,¯2147483648)
-            r,←'tLim2' desc RunVariations (,2147483648, magGen i1) (¯2147483648,i1) ⍝ Rarg to | will have the same type, and similarly the elements in the result will do as well.
+            r,←'tLim2' desc RunVariations (,2147483648, model i1) (¯2147483648,i1) ⍝ Rarg to | will have the same type, and similarly the elements in the result will do as well.
 
             case←'for singleton scalar boolean' ⍝ edge case for when a singleton scalar boolean is passed as rarg to magnitude. 
             desc←testDesc⍬

--- a/tests/residue.apln
+++ b/tests/residue.apln
@@ -5,6 +5,8 @@
 :Namespace residue
     Assert←#.unittest.Assert
 
+    model←{⍵-⍺×⌊⍵÷⍺+⍺=0} ⍝ Generator function for residue
+
     ⍝ Run Variations of each test with normal, empty and multiple shaped data
     ∇ tRes←tData RunVariations exp ;actualR;actualRE;expectedR;larg;rarg;res;tID;tCmt;shape;actualRS;shapeW0;actualRSW0
         (expectedR larg rarg)←exp
@@ -30,7 +32,7 @@
         tRes,←('ShapeW0',tID) tCmt Assert (shapeW0⍴0) ≡ actualRSW0
     ∇
 
-    ∇ r←test_residue ;genResidue;r;data;case;data2;case2;type;bool;i1;i2;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;almostd1;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
+    ∇ r←test_residue ;r;data;case;data2;case2;type;bool;i1;i2;i3;ptr;dbl;fl;cmplx;Hdbl;Hfl;Hcmplx;d1;d2;almostd1;ct;fr;⎕CT;⎕DCT;⎕FR;ct_default;dct_default;fr_dbl;fr_decf;testDesc;desc
         ct_default←1E¯14
         dct_default←1E¯28
         fr_dbl←645
@@ -54,8 +56,6 @@
         r←⍬
         testDesc←{'for ',case,{0∊⍴case2:'',⍵⋄' , ', case2,⍵},' & ⎕CT ⎕DCT:',⎕CT,⎕DCT, '& ⎕FR:', ⎕FR}
 
-        genResidue←{⍵-⍺×⌊⍵÷⍺+⍺=0} ⍝ Generator function for residue
-
         :For ct :In 0 1
             (⎕CT ⎕DCT)←ct × ct_default dct_default ⍝ set comparision tolerance
             :For fr :In 2 1
@@ -65,9 +65,9 @@
                 case←'independant'
                 case2←⍬
                 desc←testDesc⍬
-                r,← 'Ti1' desc RunVariations (0 genResidue 11) 0 11        ⍝ Special optimization for scalar 0 from iresidue at apl/allos/src/scalarscalar.cpp#L518
-                r,← 'Ti2' desc RunVariations (¯1 genResidue 11) ¯1 11      ⍝ Special optimization for scalar ¯1 from iresidue at apl/allos/src/scalarscalar.cpp#L518
-                r,← 'Ti3' desc Assert (2/(2 genResidue 1J1))≡(2|2/1J1)     ⍝ Special optimization for scans from code around apl/allos/src/arith_su.c#L1241
+                r,← 'Ti1' desc RunVariations (0 model 11) 0 11        ⍝ Special optimization for scalar 0 from iresidue at apl/allos/src/scalarscalar.cpp#L518
+                r,← 'Ti2' desc RunVariations (¯1 model 11) ¯1 11      ⍝ Special optimization for scalar ¯1 from iresidue at apl/allos/src/scalarscalar.cpp#L518
+                r,← 'Ti3' desc Assert (2/(2 model 1J1))≡(2|2/1J1)     ⍝ Special optimization for scans from code around apl/allos/src/arith_su.c#L1241
                 r,← 'Ti4' desc Assert (2/0)≡(2|2/1E40)                     ⍝ Special optimization for scans from code around apl/allos/src/arith_su.c#L1241
 
                 :For case :In 'i1' 'i2' 'i3' 'dbl' 'Hdbl' 'fl' 'Hfl' 'cmplx' 'Hcmplx' 
@@ -84,17 +84,17 @@
                             :Continue
                         :EndIf
                         data2←(≢data)↑data2                                                             ⍝ strip data2 to be equal length to data
-                        r,← 'TCross1' desc RunVariations (data genResidue data2) data data2
-                        r,← 'TCross2' desc RunVariations (data2 genResidue data) data2 data
+                        r,← 'TCross1' desc RunVariations (data model data2) data data2
+                        r,← 'TCross2' desc RunVariations (data2 model data) data2 data
                     :EndFor
 
                     case2←⍬ ⍝ disposing case2 for testDesc
                     desc←testDesc⍬
 
-                    r,← 'T1' desc RunVariations (data genResidue ⌽data) data (⌽data)                    ⍝ generator func finds results on array
+                    r,← 'T1' desc RunVariations (data model ⌽data) data (⌽data)                    ⍝ generator func finds results on array
                     d1←data[?≢data]
                     d2←data[?≢(data~d1)]
-                    r,← 'T2' desc RunVariations (d1 genResidue d2) d1 d2                                ⍝ generator func finds results on single element
+                    r,← 'T2' desc RunVariations (d1 model d2) d1 d2                                ⍝ generator func finds results on single element
                     r,← 'T3' desc RunVariations (0⍨¨data) 1 (⌊data)                                     ⍝ check remainder with 1 result is a defined output
 
                     :If (⊂data)∊i1 i2 i3
@@ -122,7 +122,7 @@
                     :Else ⍝ exact
                         ⍝ d≠d+1 for all numeric types, except when Hfl represented as DOUB
                         ⍝ if cmplx then generator function elseif negative then ⍵+1 else 1 because of 0 tolerance
-                        r,← 'CTZero' desc Assert (({⊢≠+⍵:d1 genResidue d1+1⋄1+0≤⍵⊃⍵+1 1}d1)≡d1|d1+1) ∨ (fr=1 ∧ case≡'Hfl')
+                        r,← 'CTZero' desc Assert (({⊢≠+⍵:d1 model d1+1⋄1+0≤⍵⊃⍵+1 1}d1)≡d1|d1+1) ∨ (fr=1 ∧ case≡'Hfl')
 
                         ⍝ |, ⌈ and ⌊ are added to it for getting a fixed result
                         r,← 'CTZeroAlmost1' desc Assert (0≡⌊|almostd1|d1) ∨ (fr=1 ∧ case≡'Hfl')

--- a/tests/unique.apln
+++ b/tests/unique.apln
@@ -1,8 +1,8 @@
 :Namespace unique
     Assert←#.unittest.Assert
 
-    ⍝ genUnion←{⍺,(∧/⍺≢¨⍵)/⍵} ⍝ model function for union (X∪Y) (used to model unique)
-    genUnique←{0=≢⍵:⍵ ⋄ ↑,⊃{⍺,(∧/⍺≢¨⍵)/⍵}⍨/⌽⊂¨⊂⍤¯1⊢⍵} ⍝ model function for unique
+    ⍝ modelUnion←{⍺,(∧/⍺≢¨⍵)/⍵} ⍝ model function for union (X∪Y) (used to model unique)
+    model←{0=≢⍵:⍵ ⋄ ↑,⊃{⍺,(∧/⍺≢¨⍵)/⍵}⍨/⌽⊂¨⊂⍤¯1⊢⍵} ⍝ model function for unique
 
     ⍝ util functions
     shuffle←{⊂⍤?⍨∘≢⌷⍵}              ⍝ completely Random shuffle
@@ -31,13 +31,13 @@
         ⍝ ⍝ different shapes
         shape←?(?4)/4
         actualRS←∪(shape⍴rarg)
-        expectedRS←genUnique shape⍴rarg
+        expectedRS←model shape⍴rarg
         tRes,←('Multiple',tID) tCmt Assert expectedRS ≡ actualRS
 
         ⍝ different shapes with 0 in shape
         shapeW0←(0@(?(≢shape)))shape
         actualRSW0←∪shapeW0⍴rarg
-        expectedRSW0←genUnique shapeW0⍴rarg
+        expectedRSW0←model shapeW0⍴rarg
         tRes,←('ShapeW0',tID) tCmt Assert expectedRSW0 ≡ actualRSW0
     ∇
 
@@ -124,11 +124,11 @@
                     r,← 'T4' desc RunVariations data (hashArray data intertwine data)   ⍝ using a pre-hashed array on intertwined data
 
                     shuffledData←↑shuffle data
-                    r,← 'T4' desc RunVariations (genUnique shuffledData) shuffledData   ⍝ shuffle data without creating duplicate data
+                    r,← 'T4' desc RunVariations (model shuffledData) shuffledData   ⍝ shuffle data without creating duplicate data
 
                     repetitions←?6
                     shuffledRepeatedData←↑shuffle repetitions/data
-                    r,← 'T5' desc RunVariations (genUnique shuffledRepeatedData) shuffledRepeatedData  ⍝ duplicate and shuffle
+                    r,← 'T5' desc RunVariations (model shuffledRepeatedData) shuffledRepeatedData  ⍝ duplicate and shuffle
 
                     ⍝ tests with comparision tolerance
                     :If ~(⎕DR data) ∊ 80 160 320 326 ⍝ non-numeric are skipped                  


### PR DESCRIPTION
- Closes #33 

 All models named as Generator functions (GenFloor, MagGen) have been renamed to model or modelPrimitiveName.